### PR TITLE
ci: add workflow for 5.x

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,1 @@
+paths-ignore: [test]

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,78 @@
+name: Continuous Integration (5.x branch)
+
+on:
+  push:
+    branches:
+    - 5.x
+  pull_request:
+    branches:
+    - 5.x
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10, 12, 14]
+        mongodb-version: [4.4] # the latest stable version
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.3.0
+      with:
+        mongodb-version: ${{ matrix.mongodb-version }}
+
+    - run: npm install
+    - run: npm test
+
+  code-lint:
+    name: Code Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Bootstrap project
+        run: npm install --ignore-scripts
+      - name: Verify code linting
+        run: npm run lint
+
+  commit-lint:
+    name: Commit Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Bootstrap project
+        run: npm install
+      - name: Verify commit linting
+        run: npx commitlint --from origin/5.x --to HEAD --verbose
+
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: 'javascript'
+        config-file: ./.github/codeql/codeql-config.yml
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2012,2021. All Rights Reserved.
+// Node module: loopback4-example-shopping-monorepo
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+module.exports = {
+  extends: [
+    '@commitlint/config-conventional',
+  ],
+  rules: {
+    'header-max-length': [2, 'always', 100],
+    'body-leading-blank': [2, 'always'],
+    'footer-leading-blank': [0, 'always'],
+    'signed-off-by': [2, 'always', 'Signed-off-by:'],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -46,8 +46,10 @@
     "strong-globalize": "^6.0.0"
   },
   "devDependencies": {
+    "@commitlint/config-conventional": "^13.1.0",
     "benchmark": "^2.1.4",
     "bluebird": "^3.5.4",
+    "commitlint": "^13.1.0",
     "coveralls": "^3.0.4",
     "eslint": "^6.6.0",
     "eslint-config-loopback": "^13.0.0",


### PR DESCRIPTION
The CI pipeline was not added to the 5.x branch. This PR re-enables the same CI pipeline as master.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
