### PR TITLE
Add tls connection options

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -231,7 +231,7 @@ MongoDB.prototype.connect = function(callback) {
       });
     });
   } else {
-    // See https://github.com/mongodb/node-mongodb-native/blob/3.0.0/lib/mongo_client.js#L37
+    // See https://github.com/mongodb/node-mongodb-native/blob/3.7/lib/mongo_client.js#L94
     const validOptionNames = [
       'poolSize',
       'ssl',
@@ -241,6 +241,13 @@ MongoDB.prototype.connect = function(callback) {
       'sslKey',
       'sslPass',
       'sslCRL',
+      'tls',
+      'tlsCertificateKeyFile',
+      'tlsCertificateKeyFilePassword',
+      'tlsAllowInvalidCertificates',
+      'tlsAllowInvalidHostnames',
+      'tlsInsecure',
+      'tlsCAFile',
       'autoReconnect',
       'noDelay',
       'keepAlive',


### PR DESCRIPTION
Signed-off-by: d-bo <vathsven@pm.me>

Upade validOptionNames to also support tls options as of MongoDB 4.2

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
