### PR TITLE
Update mongodb.js

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -384,7 +384,7 @@ MongoDB.prototype.getDefaultIdType = function() {
  */
 MongoDB.prototype.collectionName = function(modelName) {
   const modelClass = this._models[modelName];
-  if (modelClass.settings.mongodb) {
+  if (modelClass && modelClass.settings && modelClass.settings.mongodb) {
     modelName = modelClass.settings.mongodb.collection || modelName;
   }
   return modelName;


### PR DESCRIPTION
fixed error if this._models[modelName] is an empty object

(TypeError: Cannot read properties of undefined (reading 'settings'))

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
