### PR TITLE
Mongodb driver 4.x Upgrade

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -8,10 +8,9 @@
 /*!
  * Module dependencies
  */
-const bson = require('bson');
 const g = require('strong-globalize')();
 const mongodb = require('mongodb');
-const urlParser = require('mongodb/lib/url_parser');
+const urlParser = require('mongodb/lib/connection_string').parseOptions;
 const util = require('util');
 const async = require('async');
 const Connector = require('loopback-connector').Connector;
@@ -29,7 +28,7 @@ exports.ObjectID = ObjectID;
  * @returns {ObjectID}
  */
 function ObjectID(id) {
-  if (id instanceof mongodb.ObjectID) {
+  if (id instanceof mongodb.ObjectId) {
     return id;
   }
   if (typeof id !== 'string') {
@@ -40,7 +39,7 @@ function ObjectID(id) {
     // hex string. For LoopBack, we only allow 24-byte hex string, but 12-byte
     // string such as 'line-by-line' should be kept as string
     if (ObjectIdValueRegex.test(id)) {
-      return new bson.ObjectID(id);
+      return new mongodb.ObjectId(id);
     } else {
       return id;
     }
@@ -113,10 +112,9 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
     fsync: s.fsync || null,
   };
   s.url = s.url || generateMongoDBURL(s);
-  s.useNewUrlParser = s.useNewUrlParser !== false;
-  s.useUnifiedTopology = s.useUnifiedTopology !== false;
+  // useNewUrlParser and useUnifiedTopology are default now
   dataSource.connector = new MongoDB(s, dataSource);
-  dataSource.ObjectID = mongodb.ObjectID;
+  dataSource.ObjectID = mongodb.ObjectId;
 
   if (callback) {
     if (s.lazyConnect) {
@@ -285,8 +283,6 @@ MongoDB.prototype.connect = function(callback) {
       'validateOptions',
       'appname',
       'auth',
-      'user',
-      'password',
       'authMechanism',
       'compression',
       'readPreferenceTags',
@@ -354,17 +350,45 @@ MongoDB.prototype.connect = function(callback) {
       }
       self.client = client;
       // The database name might be in the url
-      return urlParser(self.settings.url, self.settings, function(err, url) {
-        if (err) {
-          onError(err);
-          return;
-        }
+      try {
+        const url = urlParser(self.settings.url, validOptions); // only supports the validURL options now
+        // See https://github.com/mongodb/mongodb/blob/6.0.1/lib/mongodb.d.ts#L3854
+        const validDbOptionNames = [
+          'authSource',
+          'forceServerObjectId',
+          'readPreference',
+          'pkFactory',
+          'readConcern',
+          'retryWrites',
+          'checkKeys',
+          'serializeFunctions',
+          'ignoreUndefined',
+          'promoteLongs',
+          'promoteBuffers',
+          'promoteValues',
+          'fieldsAsRaw',
+          'bsonRegExp',
+          'raw',
+          'writeConcern',
+          'logger',
+          'loggerLevel',
+        ];
+        const dbOptions = url.db_options || self.settings;
+        const dbOptionKeys = Object.keys(dbOptions);
+        const validDbOptions = {};
+        dbOptionKeys.forEach(function(option) {
+          if (validDbOptionNames.indexOf(option) > -1) {
+            validDbOptions[option] = dbOptions[option];
+          }
+        });
         self.db = client.db(
           url.dbName || self.settings.database,
-          url.db_options || self.settings,
+          validDbOptions,
         );
         if (callback) callback(err, self.db);
-      });
+      } catch (e) {
+        onError(e);
+      }
     });
   }
 };
@@ -498,7 +522,13 @@ MongoDB.prototype.execute = function(modelName, command) {
 
   // Topology is destroyed when the server is disconnected
   // Execute if DB is connected and functional otherwise connect/reconnect first
-  if (self.db && self.db.topology && !self.db.topology.isDestroyed()) {
+  if (
+    self.db && (
+      !self.db.topology || (self.db.topology && !self.db.topology.isDestroyed())
+    )
+  ) {
+    doExecute();
+  } else if (self.db && !self.db.topology) {
     doExecute();
   } else {
     if (self.db) {
@@ -545,7 +575,7 @@ MongoDB.prototype.execute = function(modelName, command) {
       'execute',
       context,
       function(context, done) {
-        args[args.length - 1] = function(err, result) {
+        const observerCallback = function(err, result) {
           if (err) {
             debug('Error: ', err);
           } else {
@@ -554,8 +584,23 @@ MongoDB.prototype.execute = function(modelName, command) {
           }
           done(err, result);
         };
-        debug('MongoDB: model=%s command=%s', modelName, command, args);
-        return collection[command].apply(collection, args);
+
+        // args had callback removed
+        if (command === 'find') {
+          // find does not support callback, remove and use a toArray with this callback
+          args.pop();
+          debug('MongoDB: model=%s command=%s', modelName, command, args);
+          try {
+            const cursor = collection[command].apply(collection, args);
+            return observerCallback(null, cursor);
+          } catch (err) {
+            return observerCallback(err, null);
+          }
+        } else {
+          args[args.length - 1] = observerCallback;
+          debug('MongoDB: model=%s command=%s', modelName, command, args);
+          return collection[command].apply(collection, args);
+        }
       },
       callback,
     );
@@ -620,7 +665,7 @@ MongoDB.prototype.create = function(modelName, data, options, callback) {
     if (err) {
       return callback(err);
     }
-    idValue = result.ops[0]._id;
+    idValue = result.insertedId;
 
     try {
       idValue = self.coerceId(modelName, idValue, options);
@@ -674,18 +719,13 @@ MongoDB.prototype.save = function(modelName, data, options, callback) {
     }
 
     const info = {};
-    if (result && result.result) {
-      // create result formats:
-      //   { ok: 1, n: 1, upserted: [ [Object] ] }
-      //   { ok: 1, nModified: 0, n: 1, upserted: [ [Object] ] }
-      //
-      // update result formats:
-      //   { ok: 1, n: 1 }
-      //   { ok: 1, nModified: 1, n: 1 }
-      if (result.result.ok === 1 && result.result.n === 1) {
-        info.isNewInstance = !!result.result.upserted;
+    if (result) {
+      // new 4.0 result formats:
+      //   { acknowledged: true, modifiedCount: 1, upsertedCount: 1, : modifiedCount: 1}
+      if (result.acknowledged === true && (result.matchedCount === 1 || result.upsertedCount === 1)) {
+        info.isNewInstance = result.upsertedCount === 1;
       } else {
-        debug('save result format not recognized: %j', result.result);
+        debug('save result format not recognized: %j', result);
       }
     }
 
@@ -854,7 +894,8 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(
     data,
     buildOptions({
       upsert: true,
-      returnOriginal: false,
+      returnNewDocument: true,
+      returnDocument: 'after', // ensures new document gets returned
       sort: [['_id', 'asc']],
     }, options),
     function(err, result) {
@@ -922,9 +963,9 @@ MongoDB.prototype.destroy = function destroy(modelName, id, options, callback) {
     if (self.debug) {
       debug('delete.callback', modelName, id, err, result);
     }
-    let res = result && result.result;
+    let res = result;
     if (res) {
-      res = {count: res.n};
+      res = {count: res.deletedCount};
     }
     if (callback) {
       callback(err, res);
@@ -1523,7 +1564,7 @@ MongoDB.prototype.destroyAll = function destroyAll(
 
     if (self.debug) debug('destroyAll.callback', modelName, where, err, info);
 
-    const affectedCount = info.result ? info.result.n : undefined;
+    const affectedCount = info ? info.deletedCount : undefined;
 
     if (callback) {
       callback(err, {count: affectedCount});
@@ -1614,7 +1655,7 @@ MongoDB.prototype.replaceWithOptions = function(modelName, id, data, options, cb
     if (err) return cb && cb(err);
     let result;
     const cbInfo = {};
-    if (info.result && info.result.n == 1) {
+    if (info && (info.matchedCount === 1 || info.upsertedCount === 1)) {
       result = self.fromDatabase(modelName, data);
       delete result._id;
       result[idName] = id;
@@ -1625,8 +1666,8 @@ MongoDB.prototype.replaceWithOptions = function(modelName, id, data, options, cb
       // replace result formats:
       //   2.4.x: { ok: 1, n: 1 }
       //   { ok: 1, nModified: 1, n: 1 }
-      if (info.result.nModified !== undefined) {
-        cbInfo.isNewInstance = info.result.nModified === 0;
+      if (info.modifiedCount !== undefined) {
+        cbInfo.isNewInstance = info.modifiedCount === 0;
       }
     } else {
       result = undefined;
@@ -1754,7 +1795,7 @@ MongoDB.prototype.update = MongoDB.prototype.updateAll = function updateAll(
       if (self.debug)
         debug('updateAll.callback', modelName, where, updateData, err, info);
 
-      const affectedCount = info.result ? info.result.n : undefined;
+      const affectedCount = info ? info.matchedCount : undefined;
 
       if (cb) {
         cb(err, {count: affectedCount});
@@ -1805,7 +1846,8 @@ MongoDB.prototype.upsertWithWhere = function upsertWithWhere(
     updateData,
     buildOptions({
       upsert: true,
-      returnOriginal: false,
+      returnNewDocument: true,
+      returnDocument: 'after', // ensures new documents get returned
       sort: [['_id', 'asc']],
     }, options),
     function(err, result) {
@@ -2040,7 +2082,7 @@ MongoDB.prototype.automigrate = function(models, cb) {
             );
             if (
               !(
-                err.name === 'MongoError' &&
+                err.name === 'MongoServerError' &&
                 err.ok === 0 &&
                 err.errmsg === 'ns not found'
               )
@@ -2188,7 +2230,7 @@ function isObjectIDProperty(modelCtor, propDef, value, options) {
     (Array.isArray(value) && value.every((v) => typeof v === 'string' && v.match(ObjectIdValueRegex)))) {
     if (isStoredAsObjectID(propDef)) return true;
     else return !isStrictObjectIDCoercionEnabled(modelCtor, options);
-  } else if (value instanceof mongodb.ObjectID) {
+  } else if (value instanceof mongodb.ObjectId) {
     return true;
   } else {
     return false;
@@ -2285,7 +2327,7 @@ function optimizedFindOrCreate(modelName, filter, data, options, callback) {
       let value = result.value;
       const created = !!result.lastErrorObject.upserted;
 
-      if (created && (value == null || Object.keys(value).length == 0)) {
+      if (created && (value == null || Object.keys(value).length === 0)) {
         value = data;
         self.setIdValue(modelName, value, result.lastErrorObject.upserted);
       } else {
@@ -2336,7 +2378,6 @@ function visitAllProperties(data, modelCtor, visitor) {
     } else {
       visitor(modelCtor, value, def, (newValue) => { data[p] = newValue; });
     }
-    continue;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bson": "^1.1.6",
         "debug": "^4.3.4",
         "loopback-connector": "^5.0.1",
-        "mongodb": "^3.7.3",
+        "mongodb": "^4.6.0",
         "strong-globalize": "^6.0.5"
       },
       "devDependencies": {
@@ -946,14 +946,14 @@
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.7.13",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "version": "18.7.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
+      "integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -962,8 +962,23 @@
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -1131,7 +1146,27 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/bcp47": {
       "version": "1.1.2",
@@ -1217,9 +1252,33 @@
     },
     "node_modules/bson": {
       "version": "1.1.6",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
       "engines": {
         "node": ">=0.6.19"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/caching-transform": {
@@ -1647,8 +1706,9 @@
       }
     },
     "node_modules/denque": {
-      "version": "1.5.1",
-      "license": "Apache-2.0",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
       "engines": {
         "node": ">=0.10"
       }
@@ -2484,6 +2544,25 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "dev": true,
@@ -2565,6 +2644,11 @@
       "funding": {
         "url": "https://github.com/sindresorhus/invert-kv?sponsor=1"
       }
+    },
+    "node_modules/ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -3386,40 +3470,40 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "3.7.3",
-      "license": "Apache-2.0",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.9.1.tgz",
+      "integrity": "sha512-ZhgI/qBf84fD7sI4waZBoLBNJYPQN5IOC++SBCiPiyhzpNKOxN/fi0tBHvH2dEC42HXtNEbFB0zmNz4+oVtorQ==",
       "dependencies": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2"
+        "bson": "^4.7.0",
+        "denque": "^2.1.0",
+        "mongodb-connection-string-url": "^2.5.3",
+        "socks": "^2.7.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12.9.0"
       },
       "optionalDependencies": {
-        "saslprep": "^1.0.0"
+        "saslprep": "^1.0.3"
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongodb/node_modules/bson": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+      "dependencies": {
+        "buffer": "^5.6.0"
       },
-      "peerDependenciesMeta": {
-        "aws4": {
-          "optional": true
-        },
-        "bson-ext": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "mongodb-extjson": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/ms": {
@@ -3696,16 +3780,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/optional-require": {
-      "version": "1.1.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "require-at": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/optionator": {
@@ -4071,8 +4145,8 @@
     },
     "node_modules/punycode": {
       "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "engines": {
         "node": ">=6"
       }
@@ -4338,13 +4412,6 @@
       "dependencies": {
         "es6-error": "^4.0.1"
       },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/require-at": {
-      "version": "1.0.6",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=4"
       }
@@ -4630,7 +4697,16 @@
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/snake-case": {
@@ -4642,9 +4718,33 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/socks": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
+      "dependencies": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "extraneous": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4913,6 +5013,17 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/traverse": {
       "version": "0.6.6",
       "dev": true,
@@ -5089,6 +5200,26 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -5894,12 +6025,14 @@
     },
     "@types/minimist": {
       "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.13",
-      "dev": true,
-      "peer": true
+      "version": "18.7.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
+      "integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -5907,7 +6040,23 @@
     },
     "@types/parse-json": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -6013,7 +6162,14 @@
       "version": "3.2.4"
     },
     "balanced-match": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcp47": {
       "version": "1.1.2"
@@ -6070,7 +6226,18 @@
       }
     },
     "bson": {
-      "version": "1.1.6"
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "caching-transform": {
       "version": "4.0.0",
@@ -6351,7 +6518,9 @@
       }
     },
     "denque": {
-      "version": "1.5.1"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="
     },
     "depd": {
       "version": "2.0.0",
@@ -6874,6 +7043,11 @@
       "version": "2.1.0",
       "dev": true
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.2.0",
       "dev": true
@@ -6920,6 +7094,11 @@
     },
     "invert-kv": {
       "version": "3.0.1"
+    },
+    "ip": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -7448,14 +7627,34 @@
       }
     },
     "mongodb": {
-      "version": "3.7.3",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.9.1.tgz",
+      "integrity": "sha512-ZhgI/qBf84fD7sI4waZBoLBNJYPQN5IOC++SBCiPiyhzpNKOxN/fi0tBHvH2dEC42HXtNEbFB0zmNz4+oVtorQ==",
       "requires": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "bson": "^4.7.0",
+        "denque": "^2.1.0",
+        "mongodb-connection-string-url": "^2.5.3",
+        "saslprep": "^1.0.3",
+        "socks": "^2.7.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
+          "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
+          "requires": {
+            "buffer": "^5.6.0"
+          }
+        }
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.3.tgz",
+      "integrity": "sha512-f+/WsED+xF4B74l3k9V/XkTVj5/fxFH2o5ToKXd8Iyi5UhM+sO9u0Ape17Mvl/GkZaFtM0HQnzAG5OTmhKw+tQ==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
       }
     },
     "ms": {
@@ -7653,12 +7852,6 @@
       "version": "5.1.2",
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "optional-require": {
-      "version": "1.1.8",
-      "requires": {
-        "require-at": "^1.0.6"
       }
     },
     "optionator": {
@@ -7892,7 +8085,8 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "q": {
       "version": "1.5.1",
@@ -8060,9 +8254,6 @@
       "requires": {
         "es6-error": "^4.0.1"
       }
-    },
-    "require-at": {
-      "version": "1.0.6"
     },
     "require-directory": {
       "version": "2.1.1",
@@ -8243,6 +8434,11 @@
       "version": "3.0.0",
       "dev": true
     },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
     "snake-case": {
       "version": "3.0.4",
       "dev": true,
@@ -8251,8 +8447,19 @@
         "tslib": "^2.0.3"
       }
     },
+    "socks": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.0.tgz",
+      "integrity": "sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==",
+      "requires": {
+        "ip": "^2.0.0",
+        "smart-buffer": "^4.2.0"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "dev": true
     },
     "sparse-bitfield": {
@@ -8441,6 +8648,14 @@
         "is-number": "^7.0.0"
       }
     },
+    "tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
     "traverse": {
       "version": "0.6.6",
       "dev": true
@@ -8548,6 +8763,20 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+    },
+    "whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "requires": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bson": "^1.1.6",
     "debug": "^4.3.4",
     "loopback-connector": "^5.0.1",
-    "mongodb": "^3.7.3",
+    "mongodb": "^4.6.0",
     "strong-globalize": "^6.0.5"
   },
   "devDependencies": {

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -127,20 +127,14 @@ describe('connect', function() {
         if (err) return done(err);
         const id = success.insertedId;
         ds.connector.should.have.property('db');
-        ds.connector.db.should.have.property('topology');
-        ds.connector.db.topology.should.have.property('isDestroyed');
-        ds.connector.db.topology.isDestroyed().should.be.False();
+
         ds.connector.disconnect(function(err) {
           if (err) return done(err);
-          // [NOTE] isDestroyed() is not implemented by NativeTopology
-          // When useUnifiedTopology is true
-          // ds.connector.db.topology.isDestroyed().should.be.True();
           ds.connector.execute('TestLazy', 'findOne', {_id: id}, function(
             err,
             data,
           ) {
             if (err) return done(err);
-            // ds.connector.db.topology.isDestroyed().should.be.False();
             done();
           });
         });
@@ -1330,7 +1324,7 @@ describe('mongodb connector', function() {
             {$rename: {name: 'firstname'}},
             function(err, updatedusers) {
               should.exist(err);
-              err.name.should.equal('MongoError');
+              err.name.should.equal('MongoServerError');
               err.errmsg.should.equal(
                 'The dollar ($) prefixed ' +
                 "field '$rename' in '$rename' is not valid for storage.",
@@ -1355,7 +1349,7 @@ describe('mongodb connector', function() {
             {$rename: {name: 'firstname'}},
             function(err, updatedusers) {
               should.exist(err);
-              err.name.should.equal('MongoError');
+              err.name.should.equal('MongoServerError');
               err.errmsg.should.equal(
                 'The dollar ($) prefixed ' +
                 "field '$rename' in '$rename' is not valid for storage.",
@@ -1412,7 +1406,7 @@ describe('mongodb connector', function() {
             options,
             function(err, updatedusers) {
               should.exist(err);
-              err.name.should.equal('MongoError');
+              err.name.should.equal('MongoServerError');
               err.errmsg.should.equal(
                 'The dollar ($) prefixed ' +
                 "field '$rename' in '$rename' is not valid for storage.",


### PR DESCRIPTION
This pull request extends @apocist work that can be checked at https://github.com/loopbackio/loopback-connector-mongodb/pull/639

Upgrades connector support to the latest MongoDb driver ^4.6.0.
The latest MongoDB driver allows access to MongoDB Altas cloud infrastructure and loadBalanced databases. Connection to this atlas service is impossible with the 3.x series at this time.

As of writing, various servers are successfully using this currently for Mongo Altas Serverless instances.

Known MongoDb Driver 4.x references found in source files and:
https://github.com/mongodb/node-mongodb-native/blob/4.0/docs/CHANGES_4.0.0.md
https://github.com/mongodb/node-mongodb-native/releases/tag/v4.1.0

Implements #638 

NOTE: There are 1 test still failing since new bson.ObjectId object instances are now not meeting lodash isEmpty checks, this should be probably fixed at [loopback-datasource-juggler repo](https://github.com/loopbackio/loopback-datasource-juggler/blob/master/lib/scope.js#L144). Maybe @achrinza or any other member have another idea, I'll be happy to implement any of them.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [ ] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
