### PR TITLE
fix(*): run autoupdate in serial to avoid conflicts

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1886,7 +1886,8 @@ MongoDB.prototype.autoupdate = function(models, cb) {
 
     const enableGeoIndexing = this.settings.enableGeoIndexing === true;
 
-    async.each(
+    // Make it serial as multiple models might map to the same collection
+    async.eachSeries(
       models,
       function(modelName, modelCallback) {
         const indexes = self._models[modelName].settings.indexes || [];
@@ -1970,7 +1971,8 @@ MongoDB.prototype.autoupdate = function(models, cb) {
           debug('create indexes: ', indexList);
         }
 
-        async.each(
+        // Make it serial as multiple indexes may try to create the same collection at once
+        async.eachSeries(
           indexList,
           function(index, indexCallback) {
             if (self.debug) {


### PR DESCRIPTION
When running a database migration with LoopBack 4 against an empty Mongo database, if there multiple indexes that need to be created in a collection that doesn't exist, then the migration may fail with "collection already exists" errors.

This happens because the `autoupdate` function runs the index creation in parallel, but the `.collection(modelName)` call triggers the collection to be created if it does not exist. This results in the possibility of multiple concurrent calls to create the same collection, all but one of which will fail.

This change uses `eachSeries` instead of `each` throughout the `autoupdate` function so migration runs serially.