### PR TITLE
chore: update Node.js and MongoDB supported versions

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -21,8 +21,12 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [14, 16, 18, 19]
-        mongodb-version: [4.4]
+        node-version: [18, 19, 20, 21]
+        mongodb-version:
+          - '4.4'
+          - '5.0'
+          - '6.0'
+          - '7.0'
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.0-alpha.1",
   "description": "The official MongoDB connector for the LoopBack framework.",
   "engines": {
-    "node": "14 || 16 || 18"
+    "node": "18 || 20"
   },
   "author": "IBM Corp.",
   "main": "index.js",
@@ -56,13 +56,5 @@
     "semver": "^7.3.7",
     "should": "^13.2.3",
     "sinon": "^12.0.1"
-  },
-  "ci": {
-    "downstreamIgnoreList": [
-      "bluemix-metering",
-      "bluemix-service-broker",
-      "bluemix-security",
-      "plan-manager"
-    ]
   }
 }


### PR DESCRIPTION
Drop v14, v16
Add v20

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>
